### PR TITLE
Unapply nonexistent function on BS ^9.0.2

### DIFF
--- a/src/weeping.ml
+++ b/src/weeping.ml
@@ -17,7 +17,7 @@ let ( <$> ) a f = match a with
 let select (type a) (query: a kind) json : a option =
   let rec prop (query: a kind) json: a option = match query with
     | Null -> Js.Json.decodeNull json <$> ignore
-    | Bool -> Js.Json.decodeBoolean json <$> Js.to_bool
+    | Bool -> Js.Json.decodeBoolean json
     | Int -> Js.Json.decodeNumber json <$> int_of_float
     | Float -> Js.Json.decodeNumber json
     | String -> Js.Json.decodeString json


### PR DESCRIPTION
This PR stops to use `Js.to_bool`, which does not exist on BS (> ? but I confirmed on bs-platform 8.2.0).